### PR TITLE
Add self-contained Homebrew tap

### DIFF
--- a/.github/workflows/homebrew-cask-bump.yml
+++ b/.github/workflows/homebrew-cask-bump.yml
@@ -1,0 +1,132 @@
+name: Bump Homebrew cask
+
+# Keeps Casks/autopip.rb pointed at the newest stable release.
+#
+# This runs on a schedule rather than on `release: published` because releases
+# are cut by another workflow using the repository token, and events raised by
+# a workflow token do not start further workflow runs.
+
+on:
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: homebrew-cask-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    name: Bump cask to latest stable
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Resolve latest stable release from the appcast
+        id: latest
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import xml.etree.ElementTree as ET
+
+          SPARKLE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+
+          root = ET.parse("appcast.xml").getroot()
+          stable = []
+          for item in root.find("channel").findall("item"):
+              # Beta items carry a <sparkle:channel>; stable items do not.
+              if item.find(f"{{{SPARKLE}}}channel") is not None:
+                  continue
+              enclosure = item.find("enclosure")
+              if enclosure is None:
+                  continue
+              short_version = enclosure.get(f"{{{SPARKLE}}}shortVersionString")
+              url = enclosure.get("url")
+              if not short_version or not url:
+                  continue
+              try:
+                  build = int(enclosure.get(f"{{{SPARKLE}}}version") or 0)
+              except ValueError:
+                  build = 0
+              stable.append((build, short_version, url))
+
+          if not stable:
+              raise SystemExit("::error::no stable item found in appcast.xml")
+
+          _, version, url = max(stable)
+          print(f"version={version}")
+          print(f"url={url}")
+          PY
+
+      - name: Compare with the cask
+        id: compare
+        env:
+          VERSION: ${{ steps.latest.outputs.version }}
+          URL: ${{ steps.latest.outputs.url }}
+        run: |
+          CURRENT=$(sed -n 's/^  version "\(.*\)"$/\1/p' Casks/autopip.rb)
+          echo "Cask: $CURRENT — appcast: $VERSION"
+
+          # The cask builds its URL as .../releases/download/v#{version}/AutoPiP.dmg;
+          # bail out instead of shipping a cask that points somewhere else.
+          EXPECTED="https://github.com/vordenken/AutoPiP/releases/download/v${VERSION}/AutoPiP.dmg"
+          if [ "$(echo "$URL" | tr '[:upper:]' '[:lower:]')" != "$(echo "$EXPECTED" | tr '[:upper:]' '[:lower:]')" ]; then
+            echo "::error::appcast URL $URL does not match the cask URL pattern $EXPECTED"
+            exit 1
+          fi
+
+          if [ "$CURRENT" = "$VERSION" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update version and checksum
+        if: steps.compare.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.latest.outputs.version }}
+          URL: ${{ steps.latest.outputs.url }}
+        run: |
+          curl -fsSL "$URL" -o AutoPiP.dmg
+          SHA256=$(sha256sum AutoPiP.dmg | cut -d' ' -f1)
+          rm -f AutoPiP.dmg
+          echo "sha256: $SHA256"
+
+          SHA256="$SHA256" python3 - <<'PY'
+          import os, re
+
+          path = "Casks/autopip.rb"
+          cask = open(path).read()
+          cask, n_version = re.subn(
+              r'^  version ".*"$', f'  version "{os.environ["VERSION"]}"', cask, count=1, flags=re.M
+          )
+          cask, n_sha = re.subn(
+              r'^  sha256 ".*"$', f'  sha256 "{os.environ["SHA256"]}"', cask, count=1, flags=re.M
+          )
+          if n_version != 1 or n_sha != 1:
+              raise SystemExit("::error::could not rewrite version/sha256 in Casks/autopip.rb")
+          open(path, "w").write(cask)
+          PY
+
+          git diff -- Casks/autopip.rb
+
+      - name: Commit and push
+        if: steps.compare.outputs.changed == 'true'
+        env:
+          VERSION: ${{ steps.latest.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/autopip.rb
+          if git diff --cached --quiet; then
+            echo "nothing to commit"
+            exit 0
+          fi
+          git commit -m "chore: update Homebrew cask for v${VERSION}"
+          git push origin main

--- a/.github/workflows/homebrew-cask.yml
+++ b/.github/workflows/homebrew-cask.yml
@@ -1,0 +1,92 @@
+name: Homebrew cask
+
+# Validates the self-contained Homebrew tap in Casks/. The checkout is turned
+# into a real tap so that the cask is exercised exactly as a user's `brew tap`
+# of this repository would be.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Casks/**'
+      - '.github/workflows/homebrew-cask.yml'
+  pull_request:
+    paths:
+      - 'Casks/**'
+      - '.github/workflows/homebrew-cask.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cask:
+    name: Audit and install
+    runs-on: macos-15
+
+    env:
+      # `brew audit --online` queries the GitHub API; without a token the
+      # runner shares an IP-based limit of 60 requests per hour.
+      HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
+      HOMEBREW_NO_ANALYTICS: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install the checkout as a tap
+        id: tap
+        run: |
+          OWNER=$(echo "${GITHUB_REPOSITORY%%/*}" | tr '[:upper:]' '[:lower:]')
+          TAP="${OWNER}/autopip"
+          TAP_PATH="$(brew --repository)/Library/Taps/${OWNER}/homebrew-autopip"
+
+          mkdir -p "$(dirname "$TAP_PATH")"
+          cp -R "$GITHUB_WORKSPACE" "$TAP_PATH"
+
+          # Homebrew 6.0 requires non-official taps to be trusted before their
+          # Ruby is evaluated. Whole-tap trust is fine on an ephemeral runner;
+          # users only need to trust the single cask (see README).
+          brew trust "$TAP"
+
+          echo "tap=$TAP" >> "$GITHUB_OUTPUT"
+          brew info --cask "${TAP}/autopip"
+
+      - name: brew style
+        run: brew style "${{ steps.tap.outputs.tap }}"
+
+      - name: brew audit
+        run: brew audit --cask --online --strict "${{ steps.tap.outputs.tap }}/autopip"
+
+      - name: brew livecheck
+        run: brew livecheck --cask --json "${{ steps.tap.outputs.tap }}/autopip"
+
+      - name: brew install
+        run: |
+          brew install --cask "${{ steps.tap.outputs.tap }}/autopip"
+          test -d /Applications/AutoPiP.app
+          test -d "/Applications/AutoPiP.app/Contents/PlugIns/AutoPiP Extension.appex"
+
+      # Releases are Apple Development signed and not notarized, so a
+      # quarantined bundle is refused at first launch. The cask's preflight
+      # clears the attribute; assert it actually did, on the installed copy
+      # that macOS would evaluate. `xattr -p` exits non-zero when the
+      # attribute is absent, which is the passing case.
+      - name: Assert the app is not quarantined
+        run: |
+          for target in \
+            /Applications/AutoPiP.app \
+            "/Applications/AutoPiP.app/Contents/PlugIns/AutoPiP Extension.appex"
+          do
+            if xattr -p com.apple.quarantine "$target" 2>/dev/null; then
+              echo "::error::$target is still quarantined; first launch would be blocked"
+              exit 1
+            fi
+            echo "ok: $target"
+          done
+
+      - name: brew uninstall --zap
+        run: |
+          brew uninstall --cask --zap "${{ steps.tap.outputs.tap }}/autopip"
+          test ! -d /Applications/AutoPiP.app

--- a/Casks/autopip.rb
+++ b/Casks/autopip.rb
@@ -1,0 +1,125 @@
+cask "autopip" do
+  version "2.0.0"
+  sha256 "8e095a94c466f02fa6b43833548d5aa73848793272132150ecb9d745613bc755"
+
+  url "https://github.com/vordenken/AutoPiP/releases/download/v#{version}/AutoPiP.dmg"
+  name "AutoPiP"
+  name "AutoPiP for Safari"
+  desc "Safari extension for automatic Picture-in-Picture video playback"
+  homepage "https://github.com/vordenken/AutoPiP"
+
+  # The appcast carries both channels: beta items have a <sparkle:channel>,
+  # stable items have none. Pick the newest item without a channel.
+  livecheck do
+    url "https://raw.githubusercontent.com/vordenken/autopip/main/appcast.xml"
+    strategy :sparkle do |items|
+      items.find { |item| item.channel.nil? }&.short_version
+    end
+  end
+
+  auto_updates true
+  # The app requires macOS 13.5; Homebrew can only express major releases.
+  depends_on macos: :ventura
+
+  app "AutoPiP.app"
+
+  # Releases are signed with an "Apple Development" certificate rather than a
+  # Developer ID, and carry no notarization ticket — `spctl -a -t execute`
+  # rejects the bundle outright. Homebrew quarantines what it installs, and
+  # Gatekeeper answers a quarantined app it rejects by refusing the first
+  # launch, so the attribute has to be gone before the app is ever opened.
+  #
+  # This runs in `preflight`, not `postflight`, and that is the whole point.
+  # Homebrew applies quarantine to the *staged* copy in the Caskroom (see
+  # Quarantine.propagate, called from Cask::Download#extract_primary_container),
+  # and PreflightBlock sorts ahead of App in Artifact::AbstractArtifact's
+  # sort_order — so this fires after staging but before the bundle is moved
+  # into /Applications. Clearing it there needs nothing but write access to
+  # Homebrew's own cache.
+  #
+  # Doing it in postflight instead would target the bundle after it has landed
+  # in /Applications, and macOS 14+ gates modifying an installed app bundle
+  # behind the App Management (TCC) permission, which the calling terminal has
+  # usually not been granted. The xattr call would fail with "Operation not
+  # permitted" and the install would report success while leaving an app macOS
+  # refuses to launch.
+  #
+  # `command.run` rather than `system_command`: the latter raises on a non-zero
+  # exit. `xattr -dr` exits non-zero for any file that does not carry the
+  # attribute — symlinks, which Quarantine.propagate skips, and every file at
+  # all once releases are notarized or when installing with
+  # HOMEBREW_CASK_OPTS=--no-quarantine. That would turn a no-op into a failed
+  # install. `run` defaults to must_succeed: false; stated explicitly so the
+  # tolerance is deliberate.
+  preflight do
+    command.run "/usr/bin/xattr",
+                args:         ["-dr", "com.apple.quarantine", "#{staged_path}/AutoPiP.app"],
+                must_succeed: false
+  end
+
+  # Belt and braces: the launched bundle is the one in /Applications, so verify
+  # it there. Gatekeeper keys the launch decision off the attribute on the app
+  # bundle itself, so checking the root is the check that matters.
+  #
+  # If it is somehow still quarantined, try once more (harmless when preflight
+  # already did the work) and fail the install with instructions rather than
+  # hand over an app that will not open. Preflight has run and the artifacts
+  # are installed by this point, so Homebrew unwinds them for us.
+  postflight do
+    installed_app = "#{appdir}/AutoPiP.app"
+
+    quarantined = lambda do
+      command.run("/usr/bin/xattr",
+                  args:         ["-p", "com.apple.quarantine", installed_app],
+                  print_stderr: false,
+                  must_succeed: false).success?
+    end
+
+    next unless quarantined.call
+
+    command.run "/usr/bin/xattr",
+                args:         ["-dr", "com.apple.quarantine", installed_app],
+                must_succeed: false
+
+    next unless quarantined.call
+
+    raise Cask::CaskError, <<~ERROR
+      Could not clear the quarantine attribute from #{installed_app}.
+
+      AutoPiP is signed with an Apple Development certificate and is not
+      notarized, so macOS would refuse to open it on first launch.
+
+      This usually means your terminal lacks App Management permission. Grant it
+      in System Settings -> Privacy & Security -> App Management, then run:
+
+        brew reinstall --cask vordenken/autopip/autopip
+
+      Or clear the attribute yourself and skip it on future installs:
+
+        xattr -dr com.apple.quarantine #{installed_app}
+        HOMEBREW_CASK_OPTS=--no-quarantine brew reinstall --cask vordenken/autopip/autopip
+    ERROR
+  end
+
+  uninstall quit: [
+    "com.vd.AutoPiP",
+    "com.vd.AutoPiP.Extension",
+  ]
+
+  zap trash: [
+    "~/Library/Application Scripts/com.vd.AutoPiP",
+    "~/Library/Application Scripts/com.vd.AutoPiP.Extension",
+    "~/Library/Containers/com.vd.AutoPiP",
+    "~/Library/Containers/com.vd.AutoPiP.Extension",
+  ]
+
+  caveats <<~EOS
+    AutoPiP is signed with an Apple Development certificate rather than a
+    Developer ID, and is not notarized. This cask therefore removes the
+    quarantine attribute during install so the first launch is not blocked —
+    macOS has not vetted this build, and you are trusting the publisher.
+
+    Launch AutoPiP once, then enable the extension in Safari under
+    Settings → Extensions. Updates are handled by Sparkle from within the app.
+  EOS
+end

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ A Safari extension that automatically enables Picture-in-Picture (PiP) mode for 
 
 > **Updating:** To receive updates, open the AutoPiP app from time to time. Sparkle checks for updates automatically (once per day).
 
+### 🍺 Install with Homebrew
+
+```sh
+brew tap vordenken/autopip https://github.com/vordenken/AutoPiP
+brew install --cask vordenken/autopip/autopip
+```
+
 ## 🎯 Compatibility
 
 | ✅ Supported | ❌ Not Supported | ⁉️ Untested |


### PR DESCRIPTION
Adds a Homebrew tap that lives **inside this repository**; no separate `homebrew-autopip` repo to create or maintain. The cask sits in `Casks/`, which is the layout Homebrew looks for in any tap.

```sh
brew tap vordenken/autopip https://github.com/vordenken/AutoPiP
brew install --cask vordenken/autopip/autopip
```

The tap URL is passed explicitly because this repo isn't named `homebrew-autopip`. Installing the fully qualified name also satisfies the [tap trust](https://docs.brew.sh/Tap-Trust) requirement introduced in [Homebrew 6.0](https://brew.sh/2026/06/11/homebrew-6.0.0/), and scopes that trust to this one cask instead of the whole tap.

### `Casks/autopip.rb`

- Tracks the **stable** channel. The default Sparkle livecheck strategy doesn't filter by channel, so the newest appcast item would be `2.1.0-beta19`; the `livecheck` block iterates `items` and picks the newest one with no `<sparkle:channel>`, which resolves to `2.0.0`.
- `auto_updates true`, so `brew upgrade` leaves Sparkle in charge.
- `depends_on macos: :ventura`; the app requires 13.5, but Homebrew can only express major releases.
- Releases are signed with an Apple Development certificate rather than a Developer ID and carry no notarization ticket, so a quarantined install is refused at first launch. A `preflight` block clears `com.apple.quarantine` on the staged copy before it's moved into `/Applications`; clearing it in `postflight` instead would need App Management (TCC) permission that the calling terminal usually doesn't have. A `postflight` block then double-checks the installed bundle and raises with recovery instructions if it's still quarantined, rather than silently handing over an app that won't open.
- `zap` removes the sandbox containers for `com.vd.AutoPiP` and `com.vd.AutoPiP.Extension`.
- `caveats` explains that quarantine is cleared automatically and macOS hasn't vetted the build, plus the one remaining manual step: enabling the extension in Safari.

### `.github/workflows/homebrew-cask.yml`

Runs on macOS whenever anything under `Casks/` changes: turns the checkout into a real tap, then `brew style`, `brew audit --cask --online --strict`, `brew livecheck`, `brew install --cask`, an assertion that the installed app and its extension are not quarantined, and `brew uninstall --cask --zap`.

### `.github/workflows/homebrew-cask-bump.yml`

Daily job that reads the newest stable item from `appcast.xml`, downloads the DMG, and rewrites `version` + `sha256` if they've drifted. It bails out if the appcast URL stops matching the cask's `.../releases/download/v#{version}/AutoPiP.dmg` pattern, so a mismatch fails loudly instead of shipping a broken cask.

It's on a schedule rather than `release: published` because the release workflow cuts releases with a workflow token, and events raised by a workflow token don't start further workflow runs. Happy to fold the bump into `build-release.yml` instead, or drop it and update the cask by hand; the cask itself doesn't depend on it.

### Verification

The cask workflow was run on a fork against `macos-15` and passed end to end: `brew style`, `brew audit --cask --online --strict`, `brew livecheck`, `brew install --cask` (app lands in `/Applications` with the extension `.appex` inside it, neither quarantined), and `brew uninstall --cask --zap`. The bump workflow was run against the current `appcast.xml`: it resolved `2.0.0`, matched the cask, and correctly made no commit.

Closes #42

## Summary by Sourcery

Add a self-contained Homebrew tap and cask for AutoPiP and wire it into documentation and CI.

New Features:
- Introduce a Homebrew cask for AutoPiP under Casks/autopip.rb, including quarantine handling, zap support, and user caveats.
- Document Homebrew-based installation in the README with the tap and cask install commands.

CI:
- Add a macOS workflow that installs this repository as a Homebrew tap and validates the cask via style, audit, livecheck, install, quarantine checks, and uninstall.
- Add a scheduled workflow to bump the Homebrew cask version and checksum to the latest stable release derived from the appcast, committing updates automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Homebrew installation support for AutoPiP on macOS.
  * Included automatic update support and cleanup of related application components.
  * Added installation guidance to the Quick Start section.

* **Bug Fixes**
  * Improved handling of macOS quarantine attributes during installation.

* **Chores**
  * Added automated validation for Homebrew installation, auditing, and removal.
  * Added automated daily updates for the Homebrew package when new stable releases are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->